### PR TITLE
[#16] Isolate FragmentTags state into its own VM

### DIFF
--- a/app/src/androidTest/java/cookpad/com/bottomnavwatson/HomeTest.kt
+++ b/app/src/androidTest/java/cookpad/com/bottomnavwatson/HomeTest.kt
@@ -1,5 +1,6 @@
 package cookpad.com.bottomnavwatson
 
+import android.content.pm.ActivityInfo
 import androidx.test.platform.app.InstrumentationRegistry
 import androidx.test.rule.ActivityTestRule
 import com.agoda.kakao.bottomnav.KBottomNavigationView
@@ -145,6 +146,21 @@ class HomeTest : TestCase() {
                 onScreen<HomeScreen> {
                     bottomNavigationView { setSelectedItem(R.id.secondTabFragment) }
                     tvTestDeepLinks { doesNotExist() }
+                }
+            }
+        }
+    }
+
+    @Test
+    fun verifyConfigChangeByRotatingDevice() {
+        run {
+            step("Rotate the device to detonate a config change") {
+                activityRule.activity.requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_LANDSCAPE
+            }
+
+            step("Check the app did not crash by asserting on any view") {
+                onScreen<HomeScreen> {
+                    textViewFirstTab { isDisplayed() }
                 }
             }
         }

--- a/bottom-nav-watson/src/main/kotlin/watson/BottomNavWatson.kt
+++ b/bottom-nav-watson/src/main/kotlin/watson/BottomNavWatson.kt
@@ -29,19 +29,21 @@ fun BottomNavigationView.setupWithNavController(
                 modelClass: Class<T>,
                 savedStateHandle: SavedStateHandle
             ): T {
-                return MultipleBackStacksViewModel(
-                    savedStateHandle = savedStateHandle,
-                    graphResId = graphResId,
-                    activity = activity,
-                    initialSelectedTabId = initialSelectedTabId,
-                    enabledTabs = enabledTabs,
-                    containerId = containerId
+                return FragmentTagsViewModel(
+                    savedStateHandle = savedStateHandle
                 ) as T
             }
         }
-    ).get(MultipleBackStacksViewModel::class.java)
+    ).get(FragmentTagsViewModel::class.java)
 
-    return viewModel.onBottomNavigationView(
+    return MultipleBackStacks(
+        fragmentTagsViewModel = viewModel,
+        graphResId = graphResId,
+        activity = activity,
+        initialSelectedTabId = initialSelectedTabId,
+        enabledTabs = enabledTabs,
+        containerId = containerId
+    ).onBottomNavigationView(
         bottomNavigationView = this,
         destinationChangedListener = destinationChangedListener,
         navigationItemReselectedListener = navigationItemReselectedListener

--- a/bottom-nav-watson/src/main/kotlin/watson/FragmentTagsViewModel.kt
+++ b/bottom-nav-watson/src/main/kotlin/watson/FragmentTagsViewModel.kt
@@ -1,0 +1,15 @@
+package watson
+
+import android.util.SparseArray
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.ViewModel
+
+internal class FragmentTagsViewModel(private val savedStateHandle: SavedStateHandle) : ViewModel() {
+    fun getTabIdToFragmentTag() = savedStateHandle[KEY_TAB_ID_TO_FRAGMENT_TAG] ?: SparseArray<FragmentTag>()
+    fun updateTabIdToFragmentTag(tabIdToFragmentTag: SparseArray<FragmentTag>) =
+        savedStateHandle.set(KEY_TAB_ID_TO_FRAGMENT_TAG, tabIdToFragmentTag)
+
+    companion object {
+        private const val KEY_TAB_ID_TO_FRAGMENT_TAG = "keyTabIdToFragmentTag"
+    }
+}

--- a/bottom-nav-watson/src/main/kotlin/watson/MultipleBackStacks.kt
+++ b/bottom-nav-watson/src/main/kotlin/watson/MultipleBackStacks.kt
@@ -8,8 +8,6 @@ import androidx.core.util.forEach
 import androidx.core.util.set
 import androidx.fragment.app.FragmentManager
 import androidx.lifecycle.MutableLiveData
-import androidx.lifecycle.SavedStateHandle
-import androidx.lifecycle.ViewModel
 import androidx.navigation.NavController
 import androidx.navigation.fragment.NavHostFragment
 import com.google.android.material.bottomnavigation.BottomNavigationView
@@ -23,16 +21,15 @@ import kotlinx.android.parcel.Parcelize
  * Original source: https://github.com/android/architectureºº-components-samples/blob/master/NavigationAdvancedSample
  * /app/src/main/java/com/example/android/navigationadvancedsample/NavigationExtensions.kt
  */
-internal class MultipleBackStacksViewModel(
-    private val savedStateHandle: SavedStateHandle,
+internal class MultipleBackStacks(
+    private val fragmentTagsViewModel: FragmentTagsViewModel,
     private val graphResId: Int,
     private val activity: AppCompatActivity,
     private val initialSelectedTabId: Int,
     private val enabledTabs: List<Int>,
     private val containerId: Int
-) : ViewModel() {
-    private val tabIdToFragmentTag: SparseArray<FragmentTag> =
-        savedStateHandle[KEY_TAB_ID_TO_FRAGMENT_TAG] ?: SparseArray<FragmentTag>()
+) {
+    private val tabIdToFragmentTag: SparseArray<FragmentTag> = fragmentTagsViewModel.getTabIdToFragmentTag()
     private val fragmentManager = activity.supportFragmentManager
     private val selectedNavController = MutableLiveData<NavController>()
     private val initialSelectedTabIndex = enabledTabs.indexOf(initialSelectedTabId)
@@ -154,7 +151,7 @@ internal class MultipleBackStacksViewModel(
 
         // Save to the map
         tabIdToFragmentTag[tabId] = FragmentTag(fragmentTag)
-        savedStateHandle.set(KEY_TAB_ID_TO_FRAGMENT_TAG, tabIdToFragmentTag)
+        fragmentTagsViewModel.updateTabIdToFragmentTag(tabIdToFragmentTag)
 
         // Update livedata with the selected graph
         selectedNavController.value = navHostFragment.navController.apply {
@@ -239,10 +236,6 @@ internal class MultipleBackStacksViewModel(
     }
 
     private fun getFragmentTag(index: Int) = "bottomNavigation#$index"
-
-    companion object {
-        private const val KEY_TAB_ID_TO_FRAGMENT_TAG = "keyTabIdToFragmentTag"
-    }
 }
 
 private fun FragmentManager.isOnBackStack(backStackName: String): Boolean {


### PR DESCRIPTION
## Overview :notebook:
As we were using `MultipleBackStacks` component as a VM all the state passed via constructor was kept between config changes, and we were passing the activity 😨 So when a config changed took place we were using the old/detached activity. The solution has been to put into that VM only the part of the state that we actually want to survive, which is the array with the mapping between fragments and tabs.   

## Links to issues/other PRs :link:
https://github.com/cookpad/BottomNavWatson/issues/16
