### PR TITLE
Persist selectedFragmentTag to saved state to avoid incorrect state

### DIFF
--- a/app/src/androidTest/java/cookpad/com/bottomnavwatson/HomeTest.kt
+++ b/app/src/androidTest/java/cookpad/com/bottomnavwatson/HomeTest.kt
@@ -165,4 +165,32 @@ class HomeTest : TestCase() {
             }
         }
     }
+
+    @Test
+    fun verifyCanSelectFirstTabAfterScreenRotate() {
+        run {
+            step("Select first tab") {
+                onScreen<HomeScreen> {
+                    bottomNavigationView { setSelectedItem(R.id.firstTabFragment) }
+                }
+            }
+            step("Select second tab") {
+                onScreen<HomeScreen> {
+                    bottomNavigationView { setSelectedItem(R.id.secondTabFragment) }
+                }
+            }
+            step("Rotate the device to detonate a config change") {
+                activityRule.activity.requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_LANDSCAPE
+            }
+
+            step("Select first tab and check contents") {
+                onScreen<HomeScreen> {
+                    bottomNavigationView { setSelectedItem(R.id.firstTabFragment) }
+                    textViewFirstTab { isDisplayed() }
+                    textViewSecondTab { doesNotExist() }
+                    textViewThirdTab { doesNotExist() }
+                }
+            }
+        }
+    }
 }

--- a/bottom-nav-watson/src/main/kotlin/com/cookpad/watson/FragmentTagsViewModel.kt
+++ b/bottom-nav-watson/src/main/kotlin/com/cookpad/watson/FragmentTagsViewModel.kt
@@ -5,11 +5,21 @@ import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 
 internal class FragmentTagsViewModel(private val savedStateHandle: SavedStateHandle) : ViewModel() {
-    fun getTabIdToFragmentTag() = savedStateHandle[KEY_TAB_ID_TO_FRAGMENT_TAG] ?: SparseArray<FragmentTag>()
-    fun updateTabIdToFragmentTag(tabIdToFragmentTag: SparseArray<FragmentTag>) =
-        savedStateHandle.set(KEY_TAB_ID_TO_FRAGMENT_TAG, tabIdToFragmentTag)
+    var tabIdToFragmentTag: SparseArray<FragmentTag>
+        get() {
+            if (savedStateHandle.get<SparseArray<FragmentTag>?>(KEY_TAB_ID_TO_FRAGMENT_TAG) == null) {
+                savedStateHandle[KEY_TAB_ID_TO_FRAGMENT_TAG] = SparseArray<FragmentTag>()
+            }
+            return savedStateHandle[KEY_TAB_ID_TO_FRAGMENT_TAG]!!
+        }
+        set(value) = savedStateHandle.set(KEY_TAB_ID_TO_FRAGMENT_TAG, value)
+
+    var selectedFragmentTag: FragmentTag?
+        get() = savedStateHandle[KEY_SELECTED_FRAGMENT_TAG]
+        set(value) = savedStateHandle.set(KEY_SELECTED_FRAGMENT_TAG, value)
 
     companion object {
         private const val KEY_TAB_ID_TO_FRAGMENT_TAG = "keyTabIdToFragmentTag"
+        private const val KEY_SELECTED_FRAGMENT_TAG = "keySelectedFragmentTag"
     }
 }


### PR DESCRIPTION
## Overview :notebook:

`selectedFragmentTag ` is not persisted to `SavedStateHandle` which leads to incorrect state after screen re-create.
1. Launch sample app
2. Select second tab
3. Rotate screen
4. Try to select first tab

ER: first tab is displayed
AR: second tab is displayed

## Screenshots, video :framed_picture:

| Before | After |
|--------|-------|
|![ezgif-7-29ef42f3a0ea](https://user-images.githubusercontent.com/13165815/92408272-41f38980-f13d-11ea-8a28-4d8d41c9b1b4.gif)|![ezgif-7-7498457d6111](https://user-images.githubusercontent.com/13165815/92408287-546dc300-f13d-11ea-8e58-323455c700b7.gif)|


## Testing :mag:
Added new UI test to cover that case, also verified that all previous tests are passing
